### PR TITLE
Opsworksified!

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ workers, and the overall maintenance state of the Matterhorn instances.
 * *-d/--debug* - adds more detailed logging output
 * *-n/--dry_run* - the script will go through the motions but not actually change anything
 * *-f/--force* - ignore some settings and wait timeouts (see more below)
+* *-o/--opsworks* - indicates an Opsworks cluster
 
 All commands are actually subcommands of the main `ec2_manager.py` program,
 and many take their own arguments and options. The structure
@@ -63,6 +64,8 @@ and opinionated about how to build multi-level command interfaces.)
 
 ### Subcommands
 
+A `*` indicates a subcommand that is not supported for Opsworks clusters.
+
 #### status
 
 Get a json dump of the cluster's status summary. Note that the 
@@ -76,7 +79,7 @@ Get a json dump of the cluster's status summary. Note that the
       -f, --format [json|table]
       --help                     Show this message and exit.
 
-#### start
+#### start `*`
 
 Starts a cluster, including any associated Zadara arrays. 
 Allows starting with a specified number of workers (default = 4).
@@ -89,7 +92,7 @@ Allows starting with a specified number of workers (default = 4).
       -w, --workers INTEGER
       --help  
       
-#### stop
+#### stop `*`
 
 Stop a cluster, including any associated Zadara arrays.
 
@@ -263,8 +266,10 @@ number of instances, workers, workers online, etc.
 
 ### Cluster naming conventions / assumptions
 
-The following assumptions are made about how ec2 instances 
-are named. 
+#### standard ec2 clusters
+
+The following assumptions are made about how instances 
+are named/tagged in standard ec2 MH clusters. 
 
 * The instance name value will be stored in the tag 'Name'
 * The instance names will all be prefixed with the name of the cluster.
@@ -275,7 +280,18 @@ e.g., all instance names in the `prdAWS` cluster will begin with `prdAWS-`
 * DB nodes will be named `[prefix]-db`
 * NFS nodes will be named `[prefix]-nfs`
 
-These assumptions hold only for the standard ec2
-Matterhorn clusters; opsworks clusters will use a different
-naming scheme and controlling them will be implemented in a 
-future release.
+#### opsworks clusters
+
+Opsworks cluster naming/tagging assumptions are slightly different.
+In addition, since the ec2-manager should not be used for doing a 
+full start/stop for opsworks clusters, "support" nodes (db, storage)
+are not manipulated.
+
+* The instance name value will be stored in the tag 'Name'
+* Instances are associated with a particular cluster via the
+`opsworks:stack` tag. e.g., all instances in the `foobar` 
+ cluster will be tagged `opsworks:stack=foobar`
+* A cluster will have one admin instance named with the tag `opsworks:layer:admin`
+* Worker nodes will have the tag `opsworks:layer:workers`
+* Engage nodes will have the tag `opsworks:layer:engage`
+

--- a/controllers/matterhorn.py
+++ b/controllers/matterhorn.py
@@ -41,8 +41,9 @@ class MatterhornController():
 
         def find_host_url(inst):
             candidate_hosts = [
-                inst.private_ip_address, # most nodes
-                inst.public_dns_name # some public-facing engage nodes
+                inst.private_ip_address,
+                inst.public_dns_name,
+                inst.private_dns_name
             ]
             host_url = None
             for h in candidate_hosts:
@@ -66,11 +67,11 @@ class MatterhornController():
         # check if we missed any hosts (e.g., the engage node usually)
         unmapped = [x for x in instances if x.id not in self.instance_host_map]
         if len(hosts) != len(unmapped) or len(hosts) > 1 or len(unmapped) > 1:
-            # big trouble
-            raise MatterhornControllerException(
-                "Unmappable instances <-> mh hosts!: {}".format(
+            # maybe trouble
+            log.warn(
+                "Unmappable instances <-> mh hosts!: instances: {}, mh hosts: {}".format(
                     ','.join(x.tags['Name'] for x in unmapped),
-                    ','.join(x.base_url for x in hosts)
+                    ','.join(x for x in hosts.keys())
                 )
             )
         elif len(hosts) == len(unmapped) == 1:

--- a/controllers/opsworks.py
+++ b/controllers/opsworks.py
@@ -1,27 +1,131 @@
+import sys
 
 import boto.opsworks
+from boto.exception import JSONResponseError
+
+from ec2 import EC2Controller, EC2Instance
+from exceptions import *
+
 import logging
-
-from ec2 import EC2Controller
-import settings
-
 log = logging.getLogger()
+
+class OpsworksEC2Instance(EC2Instance):
+
+    opsworks_instance = None
+
+    def __init__(self, wrapped, opsworks_instance):
+        super(OpsworksEC2Instance, self).__init__(wrapped)
+        self.opsworks_instance = opsworks_instance
+
 
 class OpsworksController(EC2Controller):
 
-    def __init__(self, *args, **kwargs):
-        self._opsworks = None
-        super(OpsworksController, self).__init__(*args, **kwargs)
-
     @property
     def opsworks(self):
-        if self._opsworks is None:
-            self._opsworks = self.create_opsworks_connection()
+        if not hasattr(self, '_opsworks'):
+            self._opsworks = self.create_opsworks_conn()
         return self._opsworks
 
-    def create_opsworks_connection(self):
+    def create_opsworks_conn(self):
         conn = boto.opsworks.connect_to_region(self.region,
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key
+            )
+        try:
+            conn.describe_my_user_profile()
+            log.debug("boto.opsworks connection to region %s established", self.region)
+            return conn
+        except JSONResponseError, e:
+            if e.status == '400':
+                log.error(e.message)
+                log.error("Unable to establish boto.opsworks connection. Check your aws credentials.")
+                sys.exit(1)
+            else:
+                raise
+
+    @property
+    def stack(self):
+        if not hasattr(self, '_stack'):
+            stacks = self.opsworks.describe_stacks()
+            try:
+                self._stack = next(x for x in stacks['Stacks'] if x['Name'] == self.prefix)
+            except StopIteration:
+               raise ClusterException(
+                   "Can't find a stack named {}".format(self.prefix)
+               )
+        return self._stack
+
+    @property
+    def instances(self):
+        if not hasattr(self, '_instances'):
+
+            # we only want to deal with mh nodes
+            ec2_instances = filter( self.is_mh,
+                super(OpsworksController, self).get_instances()
+            )
+
+            opsworks_instances = self.opsworks.describe_instances(self.stack['StackId'])['Instances']
+            self._instances = []
+
+            for ec2_inst in ec2_instances:
+                try:
+                    ops_inst = next(x for x in opsworks_instances if x['Ec2InstanceId'] == ec2_inst.id)
+                except StopIteration:
+                    raise ClusterException(
+                        "Cannot find matching opsworks instance for {}".format(ec2_inst.id)
+                    )
+                else:
+                    log.debug("Found matching opsworks instance %s", ops_inst['InstanceId'])
+
+                    # ignore non "24/7" opsworks instances (i.e. timer/load autoscale intances)
+                    if 'AutoScalingType' in ops_inst:
+                        log.debug("ignoring opsworks autoscale instance %s", ops_inst['InstanceId'])
+                        continue
+
+                    self._instances.append(OpsworksEC2Instance(ec2_inst, ops_inst))
+
+        return self._instances
+
+    @property
+    def instance_filter(self):
+        return {
+            'tag:opsworks:stack': self.prefix
+        }
+
+    def is_admin(self, instance):
+        return 'opsworks:layer:admin' in instance.tags
+
+    def is_worker(self, instance):
+        return 'opsworks:layer:workers' in instance.tags
+
+    def is_mh(self, instance):
+        for layer in ['admin','engage','workers']:
+            if 'opsworks:layer:' + layer in instance.tags:
+                return True
+        return False
+
+    def _start_instance(self, instance):
+        opsworks_id = instance.opsworks_instance['InstanceId']
+        if self.dry_run:
+            log.info("If this wasn't a dry run, would be starting %s, %s", opsworks_id, instance.id)
+        self.opsworks.start_instance(opsworks_id)
+
+    def _stop_instance(self, instance):
+        opsworks_id = instance.opsworks_instance['InstanceId']
+        if self.dry_run:
+            log.info("If this wasn't a dry run, would be stopping %s, %s", opsworks_id, instance.id)
+        self.opsworks.stop_instance(opsworks_id)
+
+    def _not_implemented(self, *args, **kwargs):
+        raise NotImplementedError(
+            "This operation is not implemented for opsworks clusters"
         )
-        return conn
+
+    # ec2-manager is not intended to perform these types of operations for
+    # opsworks clusters
+    start_cluster = _not_implemented
+    stop_cluster = _not_implemented
+    start_zadara = _not_implemented
+    stop_zadara = _not_implemented
+
+    is_support = _not_implemented

--- a/settings.py
+++ b/settings.py
@@ -1,11 +1,14 @@
 
-import dotenv
 from unipath import Path
 from os import getenv as env
 
+import warnings
+warnings.filterwarnings('ignore', module='dotenv')
+
+import dotenv
 dotenv.load_dotenv(Path(__file__).parent.child('.env'))
 
-VERSION = '2.1.0'
+VERSION = '2.2.0'
 
 # Matterhorn credentials and http bits
 MATTERHORN_HEADERS     = { 'X-REQUESTED-AUTH' : 'Digest', 'X-Opencast-Matterhorn-Authorization' : 'true' }
@@ -19,14 +22,14 @@ MH_SUFFIXES = ["-admin", "-worker", "-engage"]
 MAJOR_LOAD_OPERATION_TYPES = ["compose", "editor", "inspect", "video-segment"]
 
 # scaling settings
-EC2M_MAX_WORKERS = env('EC2M_MAX_WORKERS', 10)
-EC2M_MIN_WORKERS = env('EC2M_MIN_WORKERS', 2)
-EC2M_MAX_QUEUED_JOBS = env('EC2M_MAX_QUEUED_JOBS', 0)
-EC2M_MIN_IDLE_WORKERS = env('EC2M_MIN_IDLE_WORKERS', 0)
-EC2M_IDLE_UPTIME_THRESHOLD = env('EC2M_IDLE_UPTIME_THRESHOLD', 55) # this should be tweaked based on frequency of any autoscale cron jobs
+EC2M_MAX_WORKERS = int(env('EC2M_MAX_WORKERS', 10))
+EC2M_MIN_WORKERS = int(env('EC2M_MIN_WORKERS', 2))
+EC2M_MAX_QUEUED_JOBS = int(env('EC2M_MAX_QUEUED_JOBS', 0))
+EC2M_MIN_IDLE_WORKERS = int(env('EC2M_MIN_IDLE_WORKERS', 0))
+EC2M_IDLE_UPTIME_THRESHOLD = int(env('EC2M_IDLE_UPTIME_THRESHOLD', 55)) # this should be tweaked based on frequency of any autoscale cron jobs
 
-EC2M_WAIT_RETRIES = env('EC2M_WAIT_RETRIES', 10)
-EC2M_WAIT_TIME = env('EC2M_WAIT_TIME', 10)
+EC2M_WAIT_RETRIES = int(env('EC2M_WAIT_RETRIES', 10))
+EC2M_WAIT_TIME = int(env('EC2M_WAIT_TIME', 10))
 
 #AWS bits
 AWS_REGION = env('AWS_REGION', 'us-east-1')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ from controllers.ec2 import log_before_after_stats, admin_is_up
 import controllers
 
 @patch.object(utils, 'init_logging', autospec=True)
-@patch.object(ec2_manager.ec2, 'EC2Controller', autospec=True)
+@patch.object(ec2_manager, 'EC2Controller', autospec=True)
 class CliTests(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_matterhorn_controller.py
+++ b/tests/test_matterhorn_controller.py
@@ -42,21 +42,46 @@ class MatterhornControllerTests(unittest.TestCase):
             { "base_url": "http://1.1.1.1" },
             { "base_url": "http://2.2.2.2" },
             { "base_url": "https://baz" },
-            { "base_url": "https://fizzbuzz" }
+            { "base_url": "https://fizzbuzz" },
+            { "base_url": "http://blergh-private"}
         ]
         mh.client.hosts = Mock(return_value=[ServiceHost(x, mh.client) for x in fake_hosts])
         fake_instances = [
-            Mock(private_ip_address='1.1.1.1', public_dns_name="foo", id=1),
-            Mock(private_ip_address='2.2.2.2', public_dns_name="bar", id=2),
-            Mock(private_ip_address='3.3.3.3', public_dns_name="baz", id=3),
-            Mock(private_ip_address='4.4.4.4', public_dns_name="frobozz", id=4),
+            Mock(id=1,
+                 private_ip_address='1.1.1.1',
+                 public_dns_name="foo",
+                 private_dns_name="foo-private"
+                 ),
+            Mock(id=2,
+                 private_ip_address='2.2.2.2',
+                 public_dns_name="bar",
+                 private_dns_name="bar-private"
+                 ),
+            Mock(id=3,
+                 private_ip_address='3.3.3.3',
+                 public_dns_name="baz",
+                 private_dns_name="baz-private"
+                 ),
+            # this one won't explicitly match a host entry so the mapping
+            # will be (hackishly) assumed
+            Mock(id=4,
+                 private_ip_address='4.4.4.4',
+                 public_dns_name="frobozz",
+                 private_dns_name="frobozz-private"
+                 ),
+            Mock(id=5,
+                 private_ip_address='5.5.5.5',
+                 public_dns_name="blergh",
+                 private_dns_name="blergh-private"
+                 ),
         ]
         mh.create_instance_host_map(fake_instances)
         expected = {
             1: "http://1.1.1.1",
             2: "http://2.2.2.2",
             3: "https://baz",
-            4: "https://fizzbuzz"
+            4: "https://fizzbuzz",
+            5: "http://blergh-private"
         }
         self.assertEqual(mh.instance_host_map, expected)
 

--- a/tests/test_opsworks_controller.py
+++ b/tests/test_opsworks_controller.py
@@ -1,18 +1,105 @@
 
 import unittest
-import boto.opsworks
+import boto.opsworks.layer1
 import boto.ec2
 from moto import mock_ec2
-from mock import patch
+from mock import Mock, patch
 
-from controllers import OpsworksController
+from controllers import EC2Controller, OpsworksController
+from controllers.exceptions import ClusterException
 
+@patch.object(boto.ec2.EC2Connection, 'describe_account_attributes')
 class OpsworksControllerTests(unittest.TestCase):
 
     @mock_ec2
-    @patch.object(boto.ec2.EC2Connection, 'describe_account_attributes')
     def test_connection_init(self, mock_daa):
 
         ops = OpsworksController('foo')
         self.assertIsInstance(ops.connection, boto.ec2.EC2Connection)
-        self.assertIsInstance(ops.opsworks, boto.opsworks.layer1.OpsWorksConnection)
+
+    @patch.object(boto.ec2.EC2Connection, 'get_only_instances')
+    @patch.object(boto.opsworks.layer1.OpsWorksConnection, 'describe_instances')
+    def test_instances(self, mock_di, mock_goi, mock_daa):
+        mock_di.return_value = {
+            'Instances': [
+                {'InstanceId': 'asdf', 'Ec2InstanceId': 1},
+                {'InstanceId': 'fdsa', 'Ec2InstanceId': 2},
+                # this one should be ignored
+                {'InstanceId': 'zxcv', 'Ec2InstanceId': 3, 'AutoScalingType': 'timer'},
+            ]
+        }
+        mock_goi.return_value = [
+            Mock(id=1, tags={
+                'opsworks:stack': 'foobar',
+                'Name': 'abc',
+                'opsworks:layer:admin': 1
+            }),
+            Mock(id=2, tags={
+                'opsworks:stack': 'foobar',
+                'Name': 'def',
+                'opsworks:layer:workers': 1
+            }),
+            Mock(id=3, tags={
+                'opsworks:stack': 'foobar',
+                'Name': 'ghi',
+                'opsworks:layer:workers': 1
+            }),
+        ]
+        ops = OpsworksController('foobar')
+        ops._stack = {'StackId': 123}
+        self.assertIsInstance(ops.instances, list)
+        self.assertEqual(len(ops.instances), 2)
+        mock_goi.assert_called_with(filters={'tag:opsworks:stack': 'foobar'})
+
+    def test_is_admin(self, mock_daa):
+
+        ops = OpsworksController('foobar')
+        self.assertTrue(ops.is_admin(Mock(tags={
+            'opsworks:layer:admin': 'Foo'
+        })))
+        self.assertFalse(ops.is_admin(Mock(tags={
+            'opsworks:layer:foo': 'Bar'
+        })))
+
+    def test_is_worker(self, mock_daa):
+
+        ops = OpsworksController('foobar')
+        self.assertTrue(ops.is_worker(Mock(tags={
+            'opsworks:layer:workers': 'Foo'
+        })))
+        self.assertFalse(ops.is_worker(Mock(tags={
+            'opsworks:layer:werkerz': 'Bar'
+        })))
+
+    def test_is_mh(self, mock_daa):
+
+        ops = OpsworksController('foobar')
+        self.assertTrue(ops.is_mh(Mock(tags={
+            'opsworks:layer:workers': 'Worker'
+        })))
+        self.assertTrue(ops.is_mh(Mock(tags={
+            'opsworks:layer:admin': 'Admin'
+        })))
+        self.assertTrue(ops.is_mh(Mock(tags={
+            'opsworks:layer:engage': 'Engage'
+        })))
+        self.assertFalse(ops.is_mh(Mock(tags={
+            'opsworks:layer:storage': 'Storage'
+        })))
+
+    def test_stack(self, mock_daa):
+        ops = OpsworksController('foobar')
+        ops._opsworks = Mock(describe_stacks = Mock(
+            return_value={
+                'Stacks': [
+                    { 'Name': 'foobar', 'StackId': 1},
+                    { 'Name': 'froboz', 'StackId': 2}
+                ]
+            }
+        ))
+        self.assertEqual(ops.stack['StackId'], 1)
+
+        ops = OpsworksController('fizzbuzz')
+        self.assertRaises(ClusterException, getattr, ops, 'stack')
+
+

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 from functools import wraps
 import sys
 import json
+import click
 import urllib
 import urllib2
 import logging
@@ -136,4 +137,14 @@ def billed_minutes(inst):
         raise RuntimeError("Launch time from the future?!?")
     uptime_minutes = (now - launch_time).seconds / 60
     return uptime_minutes % 60
+
+def opsworks_verboten(cmd):
+    @wraps(cmd)
+    def wrapped(ec2, *args, **kwargs):
+        ctx = click.get_current_context()
+        if 'opsworks' in ctx.meta:
+            raise NotImplementedError(
+                "This command is not implemented for Opsworks clusters"
+            )
+    return wrapped
 


### PR DESCRIPTION
* `--opsworks` cmd line flag
* controller subclass to handle differences in how instances are id'ed,
  started, stopped, etc.
* start/stop cluster cmds will raise NotImplemented if invoked w/ `--opsworks`