### PR TITLE
improve handling of pyhorn/requests timeouts

### DIFF
--- a/controllers/ec2.py
+++ b/controllers/ec2.py
@@ -7,7 +7,7 @@ from wrapt import ObjectProxy
 from operator import itemgetter
 from contextlib import contextmanager
 from functools import wraps
-from requests.exceptions import ConnectTimeout
+from requests.exceptions import Timeout as RequestsTimeout
 
 import boto.ec2.networkinterface
 from boto.exception import EC2ResponseError
@@ -226,7 +226,7 @@ class EC2Controller(object):
             log.debug("Trying to fetch stats from Matterhorn")
             stats = self.mh.service_stats()
             mh_is_up = True
-        except (ConnectTimeout,MatterhornCommunicationException), e:
+        except (RequestsTimeout, MatterhornCommunicationException), e:
             log.debug("Error communicating with Matterhorn: %s", str(e))
             mh_is_up = False
 
@@ -648,7 +648,7 @@ class EC2Controller(object):
                           ','.join(x.tags['Name'] for x in for_maintenance))
                 yield # let calling code do it's thing
             except Exception, e:
-                log.error("Caught unchecked exception: %s", str(e))
+                log.debug("Exception caught during 'in_maintenance' context: %s, %s", type(e), str(e))
                 raise
             finally:
                 if restore_state:


### PR DESCRIPTION
closes #9, closes #10 

This change does not increase the pyhorn timeout value, per se. The client has a single timeout setting; if we increase it to 30 it would have consequences elsewhere. For instance, when polling to check that the admin API is available. I can't set a per-request timeout value without mucking about with changes to pyhorn.

Anyway, the problems that spawned this issue were a) I wasn't catching all the possible timeout exceptions, and b) something that was a non-error was being logged at ERROR severity (confusing).
